### PR TITLE
fix the pom so that jars are built correctly.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.version>4.3.0</cdap.version>
-    <wrangler.version>3.0.0</wrangler.version>
+    <wrangler.version>3.2.0-SNAPSHOT</wrangler.version>
     <commons-jexl.version>3.0</commons-jexl.version>
     <commons-csv.version>1.4</commons-csv.version>
     <commons-lang.version>3.5</commons-lang.version>
@@ -164,10 +164,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.14.1</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Only the plugins jar should be a bundled jar. Also update to use
the current version of wrangler, to pick up new directives and
to get the corrected smaller wrangler-core jar.