### PR TITLE
Update dependency

### DIFF
--- a/dre-api/pom.xml
+++ b/dre-api/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>co.cask.wrangler</groupId>
       <artifactId>wrangler-api</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>${wrangler.version}</version>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>

--- a/dre-plugins/pom.xml
+++ b/dre-plugins/pom.xml
@@ -30,7 +30,7 @@
   <!-- properties for script budirectivestep that creates the config files for the artifacts -->
   <widgets.dir>widgets</widgets.dir>
   <docs.dir>docs</docs.dir>
-  <app.parents>system:cdap-data-pipeline[4.2.0-SNAPSHOT,4.4.0-SNAPSHOT),system:cdap-data-streams[4.2.0-SNAPSHOT,4.4.0-SNAPSHOT)</app.parents>
+  <app.parents>system:cdap-data-pipeline[5.0.0,7.0.0),system:cdap-data-streams[5.0.0,7.0.0)</app.parents>
   <!-- this is here because project.basedir evaluates to null in the script budirectivestep -->
   <main.basedir>${project.basedir}</main.basedir>
   </properties>

--- a/dre-service/pom.xml
+++ b/dre-service/pom.xml
@@ -182,7 +182,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>2.3.7</version>
+          <version>3.3.0</version>
           <extensions>true</extensions>
           <configuration>
             <archive>
@@ -217,7 +217,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+        <version>3.3.0</version>
       </plugin>
     </plugins>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>4.3.0</cdap.version>
-    <wrangler.version>3.2.0-SNAPSHOT</wrangler.version>
+    <cdap.version>6.0.0-SNAPSHOT</cdap.version>
+    <wrangler.version>3.3.0-SNAPSHOT</wrangler.version>
     <commons-jexl.version>3.0</commons-jexl.version>
     <commons-csv.version>1.4</commons-csv.version>
     <commons-lang.version>3.5</commons-lang.version>


### PR DESCRIPTION
We bumped cdap to 6.0.0-SNAPSHOT [here](https://github.com/caskdata/cdap/pull/10814)

Updating cdap dependency