### PR TITLE
Fix compilation on develop.

### DIFF
--- a/dre-plugins/pom.xml
+++ b/dre-plugins/pom.xml
@@ -101,18 +101,9 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
-          <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>2.3.7</version>
+          <version>3.3.0</version>
           <extensions>true</extensions>
           <configuration>
             <instructions>

--- a/dre-service/pom.xml
+++ b/dre-service/pom.xml
@@ -171,15 +171,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
-          <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
           <version>3.3.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -130,8 +130,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.1</version>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>1.8</source>
+            <target>1.8</target>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Currently, compilation on develop is broken, since a [dependent class in wrangler-core now uses java 8 constructs](https://github.com/data-integrations/wrangler/commit/997c72b4711b4c299ac00b1d563990c9d4e532a9#diff-5c287ecc809f72ec3fc18ecf2bfa41bdR113). The changes in this PR resolve the issue.

```
$ mvn clean package -DskipTests

...

main:
[INFO] Executed tasks
[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ dre-plugins ---
[INFO] Building jar: /Users/alianwar/src/dre/dre-plugins/target/dre-plugins-1.2.0-SNAPSHOT.jar
[INFO] 
[INFO] --- maven-bundle-plugin:2.3.7:bundle (default) @ dre-plugins ---
java.lang.ArrayIndexOutOfBoundsException: 18
	at aQute.lib.osgi.Clazz.parseClassFile(Clazz.java:448)
	at aQute.lib.osgi.Clazz.parseClassFile(Clazz.java:369)
	at aQute.lib.osgi.Clazz.parseClassFileWithCollector(Clazz.java:359)
	at aQute.lib.osgi.Clazz.parseClassFile(Clazz.java:349)
	at aQute.lib.osgi.Analyzer.analyzeJar(Analyzer.java:1725)
	at aQute.lib.osgi.Analyzer.analyzeBundleClasspath(Analyzer.java:1618)
	at aQute.lib.osgi.Analyzer.analyze(Analyzer.java:124)
	at aQute.lib.osgi.Builder.analyze(Builder.java:306)
	at aQute.lib.osgi.Analyzer.calcManifest(Analyzer.java:301)
	at aQute.lib.osgi.Builder.build(Builder.java:73)
	at org.apache.felix.bundleplugin.BundlePlugin.buildOSGiBundle(BundlePlugin.java:547)
	at org.apache.felix.bundleplugin.BundlePlugin.execute(BundlePlugin.java:347)
	at org.apache.felix.bundleplugin.BundlePlugin.execute(BundlePlugin.java:264)
	at org.apache.felix.bundleplugin.BundlePlugin.execute(BundlePlugin.java:255)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:154)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:146)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:956)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:290)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:194)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
[ERROR] Bundle co.cask.re:dre-plugins:jar:1.2.0-SNAPSHOT : Exception: 18
[ERROR] Bundle co.cask.re:dre-plugins:jar:1.2.0-SNAPSHOT : Invalid class file: co/cask/directives/parser/ParseAvro.class
[ERROR] Error(s) found in bundle configuration
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] DRE 1.2.0-SNAPSHOT ................................. SUCCESS [  1.504 s]
[INFO] Distributed Rules Engine API ....................... SUCCESS [  4.493 s]
[INFO] Distributed Rules Engine Core ...................... SUCCESS [ 17.488 s]
[INFO] Distributed Rules Engine Plugins ................... FAILURE [ 10.330 s]
[INFO] Distributed Rules Engine Service ................... SKIPPED
[INFO] Distributed Rules Engine Convertors 1.2.0-SNAPSHOT . SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 36.523 s
[INFO] Finished at: 2018-12-06T23:23:11-08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.felix:maven-bundle-plugin:2.3.7:bundle (default) on project dre-plugins: Error(s) found in bundle configuration -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :dre-plugins
```

Compilation succeeds with these changes:
```
$ mvn clean package -DskipTests
[INFO] Scanning for projects...

...

[INFO] Reactor Summary:
[INFO] 
[INFO] DRE 1.2.0-SNAPSHOT ................................. SUCCESS [  0.904 s]
[INFO] Distributed Rules Engine API ....................... SUCCESS [  3.030 s]
[INFO] Distributed Rules Engine Core ...................... SUCCESS [ 17.284 s]
[INFO] Distributed Rules Engine Plugins ................... SUCCESS [ 19.929 s]
[INFO] Distributed Rules Engine Service ................... SUCCESS [  7.500 s]
[INFO] Distributed Rules Engine Convertors 1.2.0-SNAPSHOT . SUCCESS [  0.087 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 49.866 s
[INFO] Finished at: 2018-12-06T23:33:57-08:00
[INFO] ------------------------------------------------------------------------
```